### PR TITLE
feat: 소셜 계정 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/example/finalproject12be/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/example/finalproject12be/domain/bookmark/entity/Bookmark.java
@@ -14,9 +14,11 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 public class Bookmark {
 

--- a/src/main/java/com/example/finalproject12be/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/finalproject12be/domain/comment/entity/Comment.java
@@ -51,5 +51,4 @@ public class Comment extends Timestamped {
         this.nickname = member.getNickname();
     }
 
-
 }

--- a/src/main/java/com/example/finalproject12be/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/finalproject12be/domain/comment/repository/CommentRepository.java
@@ -16,5 +16,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByMemberId(Long memberId);
 
+    Optional<Comment> deleteCommentsByMemberId (Long memberId);
 
 }

--- a/src/main/java/com/example/finalproject12be/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/finalproject12be/domain/member/controller/MemberController.java
@@ -32,10 +32,10 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@PostMapping("/user/signup")
-	public ResponseEntity<Void> signup(@RequestBody @Valid final MemberSignupRequest memberSignupRequest) {
+	public ResponseEntity<String> signup(@RequestBody @Valid final MemberSignupRequest memberSignupRequest) {
 
 		memberService.signup(memberSignupRequest);
-		return ResponseEntity.status(HttpStatus.OK).body(null);
+		return ResponseEntity.status(HttpStatus.OK).body("회원가입 완료");
 	}
 
 	@PostMapping("/user/login")

--- a/src/main/java/com/example/finalproject12be/domain/member/entity/Member.java
+++ b/src/main/java/com/example/finalproject12be/domain/member/entity/Member.java
@@ -60,8 +60,6 @@ public class Member {
 		return new Member(email, password, nickname);
 	}
 
-
-
 	public void deleteBookmark(Bookmark bookmark){
 		this.bookmarks.remove(bookmark);
 	}

--- a/src/main/java/com/example/finalproject12be/domain/oauth/service/OauthMemberService.java
+++ b/src/main/java/com/example/finalproject12be/domain/oauth/service/OauthMemberService.java
@@ -75,6 +75,7 @@ public class OauthMemberService {
 		tokenArrayResult[3]	=  kakaoMember.getNickname();//
 
 		tokenArrayResult[4] = "Bearer " + kakaoAccessToken;
+
 		System.out.println(kakaoAccessToken + "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
 		return tokenArrayResult;
@@ -90,12 +91,12 @@ public class OauthMemberService {
 		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
 		body.add("grant_type", "authorization_code");
 
-		//body.add("client_id", "048f9445160611c1cc986c481c2d6b94");//내 앱 rest api 키
-		//body.add("redirect_uri", "http://localhost:8080/user/signin/kakao");ㅇ
+		body.add("client_id", "048f9445160611c1cc986c481c2d6b94");//내 앱 rest api 키
+		body.add("redirect_uri", "http://localhost:8080/user/signin/kakao");
 
-		body.add("client_id", "7463ed7e96bc168b9023480e535add90");//오디약 rest api 키
+		//body.add("client_id", "7463ed7e96bc168b9023480e535add90");//오디약 rest api 키
 		//body.add("redirect_uri", "https://finalproject-12-fe.vercel.app/user/signin/kakao");//오디약 redirect url
-		body.add("redirect_uri", "http://localhost:3000/user/signin/kakao");// 프런트 로컬 redirect url
+		//body.add("redirect_uri", "http://localhost:3000/user/signin/kakao");// 프런트 로컬 redirect url
 
 		body.add("code", code);
 


### PR DESCRIPTION
- member 삭제 시, member 엔티티와 comment 엔티티 사이에 외래 키 제약 조건 발생
- member 삭제 이전에 comment 삭제 실행