### PR TITLE
Fix: 이메일 인증번호 만료 시 db 삭제 로직 제거, 에러 메세지 수정

### DIFF
--- a/src/main/java/com/example/finalproject12be/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/finalproject12be/domain/member/service/MemberService.java
@@ -489,7 +489,7 @@ public class MemberService {
 		double time = validNumber.getTime();
 
 		if(formatedNow - time >= 300){ // 인증번호 발급 받은지 3분 초과
-			validNumberRepository.delete(validNumber);
+			// validNumberRepository.delete(validNumber);
 			throw new RestApiException(ValidNumberErrorCode.VALID_TIME_OVER);
 		}
 

--- a/src/main/java/com/example/finalproject12be/exception/CommonErrorCode.java
+++ b/src/main/java/com/example/finalproject12be/exception/CommonErrorCode.java
@@ -12,7 +12,7 @@ public enum CommonErrorCode implements ErrorCode {
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 글은 존재하지 않습니다"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버에서 문제가 발생했습니다"),
 	IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 IO 중 내부 서버에서 문제가 발생했습니다"),
-	INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "유효하지 않은 파라미터 입니다")
+	INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "유효하지 않은 파라미터 입니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/example/finalproject12be/exception/ValidNumberErrorCode.java
+++ b/src/main/java/com/example/finalproject12be/exception/ValidNumberErrorCode.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ValidNumberErrorCode implements ErrorCode {
 
-	VALID_TIME_OVER(HttpStatus.BAD_REQUEST, "만료시간이 지난 인증번호입니다"),
-	WRONG_NUMBER(HttpStatus.BAD_REQUEST, "인증번호가 틀렸습니다")
+	VALID_TIME_OVER(HttpStatus.BAD_REQUEST, "만료시간이 지난 인증번호입니다."),
+	WRONG_NUMBER(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다.")
 	;
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
1. db에 인증번호가 있어야 인증번호 만료 에러를 계속해서 내려줄 수 있기 때문
2. 인증번호가 일치하지 않을 시 에러 메세지 수정 ("인증번호가 틀렸습니다" -> "인증번호가 일치하지 않습니다.")
3. 2번을 포함한 이메일 인증번호에서 내려주는 에러 메세지에 모두 온점 추가